### PR TITLE
add weather applet

### DIFF
--- a/mate-applets/PKGBUILD
+++ b/mate-applets/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="Applets for MATE panel"
 arch=('i686' 'x86_64')
 license=('GPL')
 depends=('gstreamer0.10-base-plugins' 'mate-panel' 'libgtop' 'libnotify'
-         'libmatewnck')
+         'libmatewnck' 'libmateweather' )
 makedepends=('mate-doc-utils' 'pkgconfig' 'mate-settings-daemon' 'intltool'
               'mate-icon-theme' 'networkmanager') # 'mate-python-desktop' 'mate-character-map'
 groups=('mate-extras')


### PR DESCRIPTION
Byan in #mate pointed out weather applet was misisng in Arch repository. Only when libmateweather is installed does the weather applet get compiled. Therefore added "libmateweather" to dependencies.
