### PR TITLE
fixes namcap mate-file-archiver issues

### DIFF
--- a/mate-file-archiver/PKGBUILD
+++ b/mate-file-archiver/PKGBUILD
@@ -8,8 +8,8 @@ pkgrel=1
 pkgdesc="Archive manipulator for MATE"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 license=('GPL')
-depends=('desktop-file-utils' 'glib2' 'hicolor-icon-theme')
-makedepends=('mate-doc-utils' 'intltool')
+depends=('desktop-file-utils' 'dconf' 'gtk2' 'hicolor-icon-theme')
+makedepends=('mate-common' 'mate-doc-utils' 'intltool')
 conflicts=('file-roller' 'file-roller2' 'mate-extract')
 optdepends=('unrar: for RAR uncompression'
 'zip: for ZIP archives' 'unzip: for ZIP archives'


### PR DESCRIPTION
mate-file-archiver E: Dependency dconf detected and not included (needed for glib schemas)
mate-file-archiver E: Dependency gtk2 detected and not included (libraries ['usr/lib/libgtk-x11-2.0.so.0', 'usr/lib/libgdk-x11-2.0.so.0'] needed in files ['usr/bin/engrampa', 'usr/lib/caja/extensions-2.0/libcaja-engrampa.so'])
mate-file-archiver W: Dependency glib2 included but already satisfied
