### PR TITLE
Update mate-icon-theme to 1.6.2

### DIFF
--- a/mate-icon-theme/PKGBUILD
+++ b/mate-icon-theme/PKGBUILD
@@ -1,8 +1,9 @@
 #Mantainer: Giovanni "Talorno" Ricciardi <kar98k.sniper@gmail.com>
 #Contributor: Xpander <xpander0@gmail.com>
+#Contributor: Martin Wimpress <code@flexion.org>
 
 pkgname=mate-icon-theme
-pkgver=1.6.1
+pkgver=1.6.2
 pkgrel=1
 pkgdesc="MATE icon theme"
 arch=('any')
@@ -12,8 +13,7 @@ makedepends=('intltool')
 url="http://mate-desktop.org"
 groups=('mate')
 source=(http://pub.mate-desktop.org/releases/1.6/$pkgname-$pkgver.tar.xz)
-sha256sums=('7d1c22d8aa53d3003b47e52d9a961ade367f21827292143741bfcaad59059d94')
-
+sha256sums=('5596d5bb261156ca94a22bfe947690feb3d94c61b761faa2f7486e33b99711aa')
 install=mate-icon-theme.install
 
 build() {


### PR DESCRIPTION
Hi,

Despite the branch name, this updates `mate-icon-theme` to 1.6.2 that was released earlier today.

Regards, Martin.
