### PR TITLE
Fixes and tweaks for makerpo

### DIFF
--- a/makerpo
+++ b/makerpo
@@ -223,7 +223,7 @@ mr_build() {
     NEW_VER=$(echo ${NEW_VER}-${NEW_REL})
 
     if [ ! -f *$NEW_VER*.pkg.tar.xz ]; then
-      makepkg -s
+      makepkg -s --noconfirm --needed 2>&1 | tee build.log
       if [ "$?" -ne 0 ]; then
         printf '\e[1;34m======> \e[1;31mBuilding "%s" failed.\e[0m\n' "$(basename $PKG)"
         printf "Continue with package tree? [Y/n] "
@@ -240,7 +240,7 @@ mr_build() {
         printf 'Proceed to install "%s"? [Y/n] ' "$(basename $PKG)"
         read
         if [ "$REPLY" != "n" ] && [ "$REPLY" != "N" ]; then
-          sudo pacman -U $(ls *$NEW_VER*.pkg.tar.xz --color=none -t -1 | head -n 1)
+          sudo pacman -U --noconfirm $(ls *$NEW_VER*.pkg.tar.xz --color=none -t -1 | head -n 1)
         fi
       fi
     fi
@@ -253,14 +253,15 @@ mr_build() {
 # Remove Mate packages and orphan dependencies from system.
 mr_remove() {
   PKG_LIST=$(pacman -Qq)
-
-  for PKG in ${BUILD_ORDER[@]}
+  RM_PKG=""
+  for PKG in ${MATE_BUILD_ORDER[@]}
   do
+    echo $PKG
     if [ -n "$(echo $PKG_LIST | grep $PKG)" ]; then
-      RM_PKG=$(echo $RM_PKG $PKG)
+      RM_PKG="$RM_PKG $PKG"
     fi
   done
-  pacman -Rs $RM_PKG
+  sudo pacman -Rs $RM_PKG
 }
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

I've created a script to spin up a i686 and x86_64 `arch-chroot` for testing the MATE package builds. I want to streamline the process a little, so here is a little update to `makerpo`.
- Fixed `makerpo -r`.  
- `makepkg` will only install packages that are needed.
- `makepkg` will produce a `build.log` for each package. I found this useful yesterday when talking with the devs on IRC.
-  `pacman` will no longer seek confirmation if an interactive prompt has already provided consent.

Regards, Martin.
