### PR TITLE
Added `system-config-printer` as an optional requirement.

### DIFF
--- a/mate-system-tools/PKGBUILD
+++ b/mate-system-tools/PKGBUILD
@@ -2,13 +2,14 @@
 
 pkgname=mate-system-tools
 pkgver=1.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="An extension for opening terminals in arbitrary local paths"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url="http://manny.cluecoder.org/packages/nautilus-open-terminal"
 license=('GPL')
 depends=('mate-file-manager' 'liboobs' 'system-tools-backends')
 makedepends=('pkgconfig' 'intltool')
+optdepends=('system-config-printer: Add CUPS printer configuration tool.')
 install=mate-system-tools.install
 options=('!libtool')
 groups=('mate-extras')


### PR DESCRIPTION
Hi,

The `system-config-printer` package in the Arch repos compliments `mate-system-tools` by adding a  CUPS printer configuration tool. Therefore, I've added `system-config-printer` as an optional requirement to `mate-system-tools`.

Regards, Martin.
