### PR TITLE
Slight `makerpo` refactor

### DIFF
--- a/makerpo
+++ b/makerpo
@@ -68,12 +68,12 @@ AUR_BUILD_ORDER=(
 mr_help() {
     echo "$(basename ${0}) 2013.09.04 - Repository build script for Mate."
     echo
-    echo "Usage: $(basename ${0}) [option]"
+    echo "Usage: $(basename ${0}) -t [task]"
     echo
     echo "Options:"
     echo "-a  Enable automatic mode"
     echo "-h  Shows this help message."
-    echo "-t  Provide a task which can be one of:"
+    echo "-t  Provide a task to run which can be one of:"
     echo "      c|clean    Clean binary build files."
     echo "      b|build    Build Mate packages."
     echo "      d|delete   Delete all binary package files."


### PR DESCRIPTION
Hi,

I've re-factored `makerpo` a little. This pull-request does change the `makerpro` invocation slightly but does so that a a new "automatic" featured could be added.

The usage changes very slightly. Instead of:

```
./makerpo --list
```

You would use;

```
./makerpo -t list
```

The `-t` is the task flag. So you would now use `./makerpo -t build` or `./makerpo -t b` to start a build. This allows a new flag to be added `-a`. The `-a` flag enables automatic mode so that the entire package tree can be built without manual intervention.

I have a big pull-request that I am queuing up for tomorrow, and sadly, this pull-request will require merging in order for my next pull-request to apply cleanly. Sorry about that, this should be the last time my pull-requests are chained in such a fashion.

Regards, Martin.
