### PR TITLE
Move some package into a not-ready group.

### DIFF
--- a/mate-file-manager-share/PKGBUILD
+++ b/mate-file-manager-share/PKGBUILD
@@ -11,7 +11,7 @@ license=('GPL')
 depends=('mate-file-manager' 'samba')
 makedepends=('mate-common' 'perl-xml-parser')
 options=('!emptydirs' '!libtool')
-groups=('mate-extras')
+groups=('mate-not-ready')
 source=(http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz)
 sha1sums=('28e8ec54330e41aa44866107c23f48b47ea198e4')
 

--- a/mate-netbook/PKGBUILD
+++ b/mate-netbook/PKGBUILD
@@ -3,15 +3,15 @@
 
 pkgname=mate-netbook
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A simple window management tool."
 url="http://mate-desktop.org"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 license=('GPL')
-groups=('mate-extras')
 depends=('gtk2' 'libfakekey' 'libmatewnck' 'libunique' 'mate-panel')
 makedepends=('mate-common' 'mate-doc-utils' 'perl-xml-parser')
 options=('!emptydirs' '!libtool')
+groups=('mate-not-ready')
 source=(http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz)
 sha1sums=('15fd45b565585971a3bc3b7074e57ba169492cd7')
 install=${pkgname}.install


### PR DESCRIPTION
Hi,

I've noticed a couple of packages are either not working or not fully compatible with Arch Linux, so I've moved them into a `mate-not-ready` group. I'll prepare a proper TODO list in the coming days. This is a temporary measure so that new packages can be synced to the official repos.

Regards, Martin.
