### PR TITLE
Remove `mate-common` and `mate-doc-utils` from the `mate` group.

### DIFF
--- a/mate-common/PKGBUILD
+++ b/mate-common/PKGBUILD
@@ -4,14 +4,13 @@
 
 pkgname=mate-common
 pkgver=1.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Common development macros for MATE"
 arch=('any')
 license=('GPL')
 depends=('autoconf' 'automake' 'libtool' 'gettext' 'intltool' 'pkg-config' 'gtk-doc')
 options=('!emptydirs' '!libtool')
 url="http://mate-desktop.org"
-groups=('mate')
 source=(http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz)
 sha1sums=('925ffcfd96824e74a88c6a7f6265102e397fdbb5')
 

--- a/mate-doc-utils/PKGBUILD
+++ b/mate-doc-utils/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=mate-doc-utils
 pkgver=1.6.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Documentation utilities for MATE"
 url="http://mate-desktop.org"
 arch=('any')
@@ -12,7 +12,6 @@ license=('GPL' 'LGPL')
 depends=('libxml2' 'libxslt' 'python2' 'python2-lxml')
 makedepends=('mate-common' 'rarian' 'perl-xml-parser')
 options=('!emptydirs' '!libtool')
-groups=('mate')
 source=(http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz)
 sha1sums=('8a4612a21884bb6474e9d695df186551e1b9f4fb')
 


### PR DESCRIPTION
They are build requirements and not needed for a MATE desktop runtime.
