### PR TITLE
Fix conflict with the filesystem package.

### DIFF
--- a/aur/system-tools-backends/PKGBUILD
+++ b/aur/system-tools-backends/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer : Ionut Biru <ibiru@archlinux.org>
 # Contributor: Hugo Doria <hugo@archlinux.org>
+# Contributor: Martin Wimpress <code@flexion.org>
 
 pkgname=system-tools-backends
 pkgver=2.10.2
-pkgrel=2
-pkgdesc='Backends for Gnome System Tools.'
+pkgrel=3
+pkgdesc='Backends for Gnome/MATE System Tools.'
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url='http://system-tools-backends.freedesktop.org/'
 license=('GPL')
@@ -15,23 +16,20 @@ install=system-tools-backends.install
 sha256sums=('1dbe5177df46a9c7250735e05e77129fe7ec04840771accfa87690111ca2c670')
 
 build() {
-  cd ${pkgname}-${pkgver}
-
-  ./configure \
-    --prefix=/usr \
-    --with-dbus-sys=/etc/dbus-1/system.d \
-    --localstatedir=/var \
-    --mandir=/usr/share \
-    --disable-static
-
-  make
+    cd ${pkgname}-${pkgver}
+    ./configure \
+        --prefix=/usr \
+        --with-dbus-sys=/etc/dbus-1/system.d \
+        --localstatedir=/var \
+        --mandir=/usr/share \
+        --sbindir=/usr/bin \
+        --disable-static
+    make
 }
 
 package() {
-  cd ${pkgname}-${pkgver}
-
-  make DESTDIR=${pkgdir} install
-
-  #clean up man
-  rm -rf $pkgdir/usr/share/system-tools-backends-2.0/modules/share/
+    cd ${pkgname}-${pkgver}
+    make DESTDIR=${pkgdir} install
+    #clean up man
+    rm -rf ${pkgdir}/usr/share/system-tools-backends-2.0/modules/share/
 }


### PR DESCRIPTION
Hi,

Just been testing a fresh install of Arch Linux when the `base`, `mate` and `mate-extra` packages are installed via `pacstrap`. The `filesystem` and `system-tools-backends` packages conflict, this pull-request fixes that.

Regards, Martin.
