### PR TITLE
Fixed invest applet and disable timer applet

### DIFF
--- a/mate-applets/PKGBUILD
+++ b/mate-applets/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=mate-applets
 pkgver=1.6.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Applets for MATE panel"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url="http://mate-desktop.org"
@@ -45,7 +45,6 @@ package() {
     # Remove Python byte-code
     rm -rf ${pkgdir}/usr/lib/python2.*/site-packages/mate_invest/*.py{c,o}
     # Use python2
-    sed -i '1i\
-    #!/usr/bin/env python2' ${pkgdir}/usr/lib/${pkgname}/invest-applet
+    sed -i 's/env python/env python2/' ${pkgdir}/usr/lib/${pkgname}/invest-applet
 
 }


### PR DESCRIPTION
Hi,

I've fixed the Invest applet and disabled the timer applet. The timer applet has not yet been ported to gsettings so is not compatible with MATE 1.6.

Regards, Martin.
