### PR TITLE
Fix `mate-netbook` startup delay.

### DIFF
--- a/mate-netbook/PKGBUILD
+++ b/mate-netbook/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=mate-netbook
 pkgver=1.6.0
-pkgrel=4
+pkgrel=5
 pkgdesc="A simple window management tool."
 url="http://mate-desktop.org"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
@@ -11,7 +11,6 @@ license=('GPL')
 depends=('gtk2' 'libfakekey' 'libmatewnck' 'libunique' 'mate-panel')
 makedepends=('mate-common' 'mate-doc-utils' 'perl-xml-parser')
 options=('!emptydirs' '!libtool')
-groups=('mate-extras')
 source=(http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz)
 sha1sums=('15fd45b565585971a3bc3b7074e57ba169492cd7')
 install=${pkgname}.install


### PR DESCRIPTION
Hi,

I problem was reported with `mate-netbook` that causes significant delay starting panel applets and startup applications.

Problem discussed from the post onward:
- http://forums.mate-desktop.org/viewtopic.php?f=4&t=1872#p6627

Work around documented here:
- https://github.com/mate-desktop/mate-netbook/issues/6

I've also remove `mate-netbook` from the `mate-extras` group. It simply doesn't make sense to install it by default because it change the window manager behaviour that isn't desireable for most users.

Regards, Martin.
