### PR TITLE
Remove .a files detected by 'builder.sh -t audit'.

### DIFF
--- a/mate-file-manager-gksu/PKGBUILD
+++ b/mate-file-manager-gksu/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=mate-file-manager-gksu
 pkgver=1.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="An extension for opening terminals in arbitrary local paths"
 url="http://manny.cluecoder.org/packages/nautilus-open-terminal"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
@@ -26,4 +26,5 @@ build() {
 package() {
     cd ${srcdir}/${pkgname}-${pkgver}
     make DESTDIR="${pkgdir}" install
+    rm -f ${pkgdir}/usr/lib/caja/extensions-2.0/libcaja-gksu.a
 }

--- a/mate-file-manager-open-terminal/PKGBUILD
+++ b/mate-file-manager-open-terminal/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=mate-file-manager-open-terminal
 pkgver=1.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="An extension for opening terminals in arbitrary local paths"
 url="http://manny.cluecoder.org/packages/nautilus-open-terminal"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
@@ -27,4 +27,5 @@ build() {
 package() {
 	cd ${srcdir}/${pkgname}-${pkgver}
 	make DESTDIR="${pkgdir}" install
+	rm -f ${pkgdir}/usr/lib/caja/extensions-2.0/libcaja-open-terminal.a
 }

--- a/mate-system-tools/PKGBUILD
+++ b/mate-system-tools/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=mate-system-tools
 pkgver=1.6.0
-pkgrel=4
+pkgrel=5
 pkgdesc="An extension for opening terminals in arbitrary local paths"
 url="http://manny.cluecoder.org/packages/nautilus-open-terminal"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
@@ -33,4 +33,5 @@ build() {
 package() {
     cd ${srcdir}/${pkgname}-${pkgver}
     make DESTDIR="${pkgdir}" install
+    rm -f ${pkgdir}/usr/lib/caja/extensions-2.0/libcaja-gst-shares.a
 }


### PR DESCRIPTION
Hi,

`builder.sh -t audit` identified some static libraries in a few packages, these PKGBUILD updates remove them.

Regards, Martin.
