### PR TITLE
mate-user-share: disable bluetooth support

### DIFF
--- a/mate-user-share/PKGBUILD
+++ b/mate-user-share/PKGBUILD
@@ -3,19 +3,27 @@
 
 pkgname=mate-user-share
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="User level public file sharing via WebDAV or ObexFTP."
 url="http://mate-desktop.org"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 license=('GPL')
-depends=('apache' 'dbus' 'desktop-file-utils' 'gtk2' 'libcanberra' 'libnotify'
-         'libunique' 'mate-bluetooth' 'mate-file-manager' 'mod_dnssd' 'obex-data-server')
-makedepends=('mate-common' 'mate-doc-utils' 'perl-xml-parser')
+depends=('apache' 'dconf' 'libunique' 'mod_dnssd')
+makedepends=('libcanberra' 'libnotify' 'mate-common' 'mate-doc-utils'
+             'mate-file-manager' 'perl-xml-parser')
 options=('!emptydirs')
 groups=('mate-extras')
-source=("http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz")
-sha1sums=('03f5731a29bc53a9ff6882d33b2a45d0270e48e1')
 install=${pkgname}.install
+source=("http://pub.mate-desktop.org/releases/1.6/${pkgname}-${pkgver}.tar.xz"
+        "make-bluetooth-optional.patch")
+sha1sums=('03f5731a29bc53a9ff6882d33b2a45d0270e48e1'
+          '886d06a6cd0c5158b93a72c82d05b11481d25142')
+
+prepare() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    # Make bluetooth optional
+    patch -Np1 -i "${srcdir}/make-bluetooth-optional.patch"
+}
 
 build() {
     cd "${srcdir}/${pkgname}-${pkgver}"
@@ -24,7 +32,8 @@ build() {
         --libexec=/usr/lib/${pkgname} \
         --sysconfdir=/etc \
         --disable-static \
-        --disable-scrollkeeper
+        --disable-scrollkeeper \
+        --disable-bluetooth
     make
 }
 

--- a/mate-user-share/make-bluetooth-optional.patch
+++ b/mate-user-share/make-bluetooth-optional.patch
@@ -1,0 +1,113 @@
+diff -Naur mate-user-share-1.6.0.orig/configure.in mate-user-share-1.6.0/configure.in
+--- mate-user-share-1.6.0.orig/configure.in	2013-04-02 23:49:30.000000000 +0200
++++ mate-user-share-1.6.0/configure.in	2013-12-18 08:58:07.948427940 +0100
+@@ -56,20 +56,20 @@
+    AC_DEFINE(HAVE_DBUS_1_1, 1, [Set to true if we have D-BUS 1.1])
+ fi
+ 
+-PKG_CHECK_MODULES(USER_SHARE, glib-2.0 >= 2.15.2 gio-2.0 >= 2.25.0 gdk-x11-2.0 gtk+-2.0 dbus-glib-1 libnotify >= 0.7.0 libcanberra-gtk $DBUS_MODULES)
+-AC_SUBST(USER_SHARE_CFLAGS)
+-AC_SUBST(USER_SHARE_LIBS)
+-
+-PKG_CHECK_MODULES(BLUETOOTH, mate-bluetooth-1.0 >= 1.2.0,
+-                             have_bluetooth=true, have_bluetooth=false)
+-AC_SUBST(BLUETOOTH_CFLAGS)
+-AC_SUBST(BLUETOOTH_LIBS)
+-if $have_bluetooth; then
+-   AC_DEFINE(HAVE_BLUETOOTH, 1, [Set to true if mate-bluetooth support is available])
++BLUETOOTH_PKG="mate-bluetooth-1.0 >= 1.2.0"
++AC_ARG_ENABLE(bluetooth, AS_HELP_STRING([--disable-bluetooth],[compile without bluetooth support]),,enable_bluetooth=yes)
++if test "x$enable_bluetooth" = "xyes"; then
++ PKG_CHECK_MODULES(BLUETOOTH, $BLUETOOTH_PKG)
++ AC_DEFINE(HAVE_BLUETOOTH, 1, [Set to true if mate-bluetooth support is available])
+ else
+-   AC_MSG_WARN([Bluetooth support is disabled.])
++ BLUETOOTH_PKG=""
++ AC_MSG_WARN([Bluetooth support is disabled.])
+ fi
+-AM_CONDITIONAL(USE_BLUETOOTH, [test "$have_bluetooth" = "true"])
++AM_CONDITIONAL(USE_BLUETOOTH, [test "$enable_bluetooth" = "yes"])
++
++PKG_CHECK_MODULES(USER_SHARE, glib-2.0 >= 2.15.2 gio-2.0 >= 2.25.0 gdk-x11-2.0 gtk+-2.0 dbus-glib-1 libnotify >= 0.7.0 libcanberra-gtk $DBUS_MODULES $BLUETOOTH_PKG)
++AC_SUBST(USER_SHARE_CFLAGS)
++AC_SUBST(USER_SHARE_LIBS)
+ 
+ PKG_CHECK_MODULES(USER_SHARE_CONFIG, glib-2.0 >= 2.15.2 gio-2.0 >= 2.25.0 gtk+-2.0 >= 2.12.0 unique-1.0)
+ AC_SUBST(USER_SHARE_CONFIG_CFLAGS)
+@@ -145,7 +145,7 @@
+ 	    [ac_with_cajadir=""])
+ 
+ PKG_CHECK_MODULES(EXTENSION,
+-		   libcaja-extension mate-bluetooth-1.0)
++		   libcaja-extension $BLUETOOTH_PKG)
+ if test "${ac_with_cajadir}" = ""; then
+ 	ac_with_cajadir=`pkg-config --variable=extensiondir libcaja-extension`
+ fi
+diff -Naur mate-user-share-1.6.0.orig/src/share-extension.c mate-user-share-1.6.0/src/share-extension.c
+--- mate-user-share-1.6.0.orig/src/share-extension.c	2013-04-02 23:49:30.000000000 +0200
++++ mate-user-share-1.6.0/src/share-extension.c	2013-12-18 08:58:07.948427940 +0100
+@@ -27,10 +27,13 @@
+ #include <string.h>
+ #include <glib/gi18n-lib.h>
+ #include <gtk/gtk.h>
+-#include <bluetooth-client.h>
+ #include <libcaja-extension/caja-menu-provider.h>
+ #include <libcaja-extension/caja-location-widget-provider.h>
+ 
++#ifdef HAVE_BLUETOOTH
++#include <bluetooth-client.h>
++#endif
++
+ #include "caja-share-bar.h"
+ #include "user_share-common.h"
+ 
+@@ -101,6 +104,7 @@
+         }
+ }
+ 
++#ifdef HAVE_BLUETOOTH
+ static void
+ downloads_bar_set_from_bluetooth_status (GtkWidget *bar)
+ {
+@@ -121,6 +125,7 @@
+ {
+ 	downloads_bar_set_from_bluetooth_status (bar);
+ }
++#endif /* HAVE_BLUETOOTH */
+ 
+ static GtkWidget *
+ caja_user_share_get_location_widget (CajaLocationWidgetProvider *iface,
+@@ -163,8 +168,13 @@
+ 	if (is_dir[0] != FALSE && is_dir[1] != FALSE) {
+ 		bar = caja_share_bar_new (_("May be used to share or receive files"));
+ 	} else if (is_dir[0] != FALSE) {
++#ifndef HAVE_BLUETOOTH
+ 		bar = caja_share_bar_new (_("May be shared over the network or Bluetooth"));
++#else
++		bar = caja_share_bar_new (_("May be shared over the network"));
++#endif /* !HAVE_BLUETOOTH */
+ 	} else {
++#ifdef HAVE_BLUETOOTH
+ 		BluetoothClient *client;
+ 
+ 		bar = caja_share_bar_new (_("May be used to receive files over Bluetooth"));
+@@ -175,6 +185,7 @@
+ 		g_signal_connect (G_OBJECT (client), "notify::default-adapter-powered",
+ 				  G_CALLBACK (default_adapter_powered_cb), bar);
+ 		downloads_bar_set_from_bluetooth_status (bar);
++#endif /* HAVE_BLUETOOTH */
+ 	}
+ 
+ 	g_signal_connect (bar, "response",
+diff -Naur mate-user-share-1.6.0.orig/src/user_share.c mate-user-share-1.6.0/src/user_share.c
+--- mate-user-share-1.6.0.orig/src/user_share.c	2013-04-02 23:49:30.000000000 +0200
++++ mate-user-share-1.6.0/src/user_share.c	2013-12-18 09:16:00.853342521 +0100
+@@ -346,7 +346,7 @@
+ 		http_down ();
+ 		disabled_timeout_tag = g_timeout_add_seconds (3,
+ 							      (GSourceFunc)disabled_timeout_callback,
+-							      client);
++							      settings);
+ 	}
+ }
+ 

--- a/mate-user-share/mate-user-share.install
+++ b/mate-user-share/mate-user-share.install
@@ -1,7 +1,6 @@
 post_install() {
     glib-compile-schemas /usr/share/glib-2.0/schemas/
     gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-    update-desktop-database -q
 }
 
 post_upgrade() {


### PR DESCRIPTION
mate-bluetooth is not yet ported to bluez5. Various other fixes.

This allows to move mate-user-share into the official repositories without mate-bluetooth.
